### PR TITLE
updated Result.createResults.. method to reference correct instance o…

### DIFF
--- a/server/api/results.js
+++ b/server/api/results.js
@@ -36,7 +36,7 @@ router.get('/test/:pageTestId', (req, res, next) => {
 // POST /api/results/
 router.post('/', (req, res, next) => {
   const url = req.body.url
-  return Promise.resolve(webby(url))
+  return webby(url)
   .then(data => Result.createResultsForPage(data, url))
   .then(_ => console.log("Result post request complete"))
   .then(_ => res.sendStatus(201))

--- a/server/api/results.js
+++ b/server/api/results.js
@@ -36,7 +36,7 @@ router.get('/test/:pageTestId', (req, res, next) => {
 // POST /api/results/
 router.post('/', (req, res, next) => {
   const url = req.body.url
-  return webby(url)
+  return Promise.resolve(webby(url))
   .then(data => Result.createResultsForPage(data, url))
   .then(_ => console.log("Result post request complete"))
   .then(_ => res.sendStatus(201))

--- a/server/db/models/result.js
+++ b/server/db/models/result.js
@@ -35,21 +35,14 @@ const Result = db.define('result', {
 // .then(atts => console.log(atts))
 
 Result.createResultsForPage = function (bulkAttData, url) {
-    // // Issue with the 'findAll' version, throwing errors:
-
-    // return PageTest.findAll({ limit: 1, where: { url }, order: [['createdAt', 'DESC']] })
-
-    // // "Unhandled rejection Error: Invalid value [object SequelizeInstance:pageTest]"
-    // // Using code below in meantime as workaround, does not work with multiple instances of same URL
-
-    return PageTest.findOne({ where: { url } })
+    return PageTest.findAll({ limit: 1, where: { url }, order: [['createdAt', 'DESC']] })
     .then(pt => Promise.all(bulkAttData.map(attData => {
       return Result.create({
         tagName: attData[0],
         href: attData[1],
         innerHTML: attData[2],
       })
-      .then(result => result.setPageTest(pt))
+      .then(result => result.setPageTest(pt[0]))
     })))
     .then(_ => console.log("create results complete"))
     .catch(err => console.error(err))

--- a/server/utils/webdriver-hailmary.js
+++ b/server/utils/webdriver-hailmary.js
@@ -21,6 +21,7 @@ function webby (u) {
             return Promise.all(['tagName', 'href', 'innerHTML']
             .map(attribute => element.getAttribute(attribute)
                  .then(attValue => {
+                    if (!attValue) return 'No value'
                     return attValue.trim()
                 })
             ))


### PR DESCRIPTION
closes #21 

Turned out to not be an async issue, but a symptom of the known issue with correctly associating the right instance of a pagetest URL with a result, where duplicates of the same URL appears in multiple pageTests. This has been addressed via Sequelize query.